### PR TITLE
Remove support for loading using LD_PRELOAD

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -1,6 +1,6 @@
-#define _GNU_SOURCE // program_invocation_short_name
+#define _GNU_SOURCE
 #include <dlfcn.h>
-#include <errno.h> // program_invocation_short_name
+#include <errno.h>
 #include <link.h>
 #include <pthread.h>
 #include <stdlib.h>
@@ -15,11 +15,6 @@
 #include "util.h"
 
 __attribute__((constructor)) void nm_init() {
-    // for if it's been loaded with LD_PRELOAD rather than as a Qt plugin
-    if (strcmp(program_invocation_short_name, "nickel"))
-        if (!(getenv("LIBNM_FORCE") && !strcmp(getenv("LIBNM_FORCE"), "true")))
-            return;
-
     char *err;
 
     NM_LOG("version: " NM_VERSION);


### PR DESCRIPTION
It hasn't been used except for before the initial release, and it's more likely to cause odd issues when parts of NM are reused by other mods.