### PR TITLE
Fix cmd_output newlines not being displayed

### DIFF
--- a/src/action_cc.cc
+++ b/src/action_cc.cc
@@ -3,6 +3,7 @@
 #include <QScreen>
 #include <QString>
 #include <QStringList>
+#include <QTextDocument>
 #include <QUrl>
 #include <QVariant>
 #include <QWidget>
@@ -853,5 +854,5 @@ NM_ACTION_(cmd_output) {
 
     return quiet
         ? nm_action_result_silent()
-        : nm_action_result_msg("%s", qPrintable(out));
+        : nm_action_result_msg("%s", qPrintable(Qt::convertFromPlainText(out, Qt::WhiteSpacePre)));
 }

--- a/src/nickelmenu.cc
+++ b/src/nickelmenu.cc
@@ -44,6 +44,7 @@ static QAction* (*AbstractNickelMenuController_createAction)(void*, QMenu* menu,
 
 // ConfirmationDialogFactory::showOKDialog shows an dialog box with an OK
 // button, and should only be called from the main thread (or a signal handler).
+// Note that ConfirmationDialog uses Qt::RichText for the body.
 static void (*ConfirmationDialogFactory_showOKDialog)(QString const& title, QString const& body);
 
 MainWindowController *(*MainWindowController_sharedInstance)();


### PR DESCRIPTION
ConfirmationDialog uses Qt::RichText for the body text, which causes line breaks to be collapsed since the text is rendered as HTML. This can be fixed by using Qt::convertFromPlainText with Qt::WhiteSpacePre.

fixes #92 