### PR TITLE
Implement nickel_bluetooth action

### DIFF
--- a/res/doc
+++ b/res/doc
@@ -149,9 +149,11 @@
 #                                          sleep    (4.13.12638+)
 #                   skip               - the number of actions to skip, or -1 to skip all remaining ones (i.e. end the chain)
 #                   nickel_bluetooth   - one of:
-#                                          enable
-#                                          disable
-#                                          toggle
+#                                          enable   (4.34.20097+)
+#                                          disable  (4.34.20097+)
+#                                          toggle   (4.34.20097+)
+#                                          check    (4.34.20097+)
+#                                          scan     (4.34.20097+)
 #
 #   chain_success:<action>:<arg>
 #   chain_failure:<action>:<arg>

--- a/res/doc
+++ b/res/doc
@@ -65,6 +65,7 @@
 #                   nickel_misc        - other stuff which isn't significant enough for its own category
 #                   nickel_open        - opens a view
 #                   nickel_wifi        - controls wifi (note: it doesn't wait for it to connect or disconnect, neither does it check for success)
+#                   nickel_bluetooth   - controls bluetooth
 #                   nickel_orientation - controls screen orientation
 #                                        (devices without an orientation sensor may need to use the kobopatch patch "Allow rotation on all devices" or set [DeveloperSettings] ForceAllowLandscape=true)
 #                                        (devices with an orientation sensor don't need to do anything, but can set the config setting to make this work on all views)
@@ -147,6 +148,10 @@
 #                                          reboot   (4.13.12638+)
 #                                          sleep    (4.13.12638+)
 #                   skip               - the number of actions to skip, or -1 to skip all remaining ones (i.e. end the chain)
+#                   nickel_bluetooth   - one of:
+#                                          enable
+#                                          disable
+#                                          toggle
 #
 #   chain_success:<action>:<arg>
 #   chain_failure:<action>:<arg>

--- a/src/action.h
+++ b/src/action.h
@@ -50,6 +50,7 @@ void nm_action_result_free(nm_action_result_t *res);
     X(nickel_misc)        \
     X(nickel_open)        \
     X(nickel_wifi)        \
+    X(nickel_bluetooth)   \
     X(nickel_orientation) \
     X(power)              \
     X(skip)

--- a/src/action_cc.cc
+++ b/src/action_cc.cc
@@ -898,7 +898,6 @@ NM_ACTION_(cmd_output) {
         : nm_action_result_msg("%s", qPrintable(Qt::convertFromPlainText(out, Qt::WhiteSpacePre)));
 }
 
-
 NM_ACTION_(nickel_bluetooth) {
     bool enable=true, toggle=false;
     if      (!strcmp(arg, "enable"))      enable = true;
@@ -911,11 +910,10 @@ NM_ACTION_(nickel_bluetooth) {
     BluetoothManager *(*BluetoothManager_sharedInstance)();
     NM_ACT_XSYM(BluetoothManager_sharedInstance, "_ZN16BluetoothManager14sharedInstanceEv", "could not dlsym BluetoothManager::sharedInstance");
 
-
     BluetoothManager *btm = BluetoothManager_sharedInstance();
     NM_CHECK(nullptr, btm, "could not get shared bluetooth manager pointer");
 
-    if (toggle){
+    if (toggle) {
         //_ZNK16BluetoothManager2upEv - returns 1 if bluetooth is turned on.
         uint (*BluetoothManager_up)(BluetoothManager *);
         NM_ACT_XSYM(BluetoothManager_up, "_ZNK16BluetoothManager2upEv", "could not dlsym BluetoothManager::up");
@@ -924,11 +922,13 @@ NM_ACTION_(nickel_bluetooth) {
         enable = isUp ? false : true;
     }
 
-    if (enable){
+    if (enable) {
         void (*BluetoothManager_on)(BluetoothManager *);
         NM_ACT_XSYM(BluetoothManager_on, "_ZN16BluetoothManager2onEv", "could not dlsym BluetoothManager::on");
         BluetoothManager_on(btm);
-    }else{
+    } else {
+	
+	    //libnickel 4.33 * _ZN16BluetoothManager3offEv
         void (*BluetoothManager_off)(BluetoothManager *);
         NM_ACT_XSYM(BluetoothManager_off, "_ZN16BluetoothManager3offEv", "could not dlsym BluetoothManager::off");
         BluetoothManager_off(btm);

--- a/src/action_cc.cc
+++ b/src/action_cc.cc
@@ -932,7 +932,7 @@ NM_ACTION_(nickel_bluetooth) {
     void (*BluetoothManager_scan)(BluetoothManager *);
     NM_ACT_XSYM(BluetoothManager_scan, "_ZN16BluetoothManager4scanEv", "could not dlsym BluetoothManager::BluetoothManager::scanEv");
 
-    //libnickel 4.34.20097 *_ZN16BluetoothManager8stopScanEv
+    //libnickel 4.34.20097 * _ZN16BluetoothManager8stopScanEv
     void (*BluetoothManager_stopScan)(BluetoothManager *);
     NM_ACT_XSYM(BluetoothManager_stopScan, "_ZN16BluetoothManager8stopScanEv", "could not dlsym BluetoothManager::stopScan");
 


### PR DESCRIPTION
Implementation of a new action "nickel_bluetooth" to turn Bluetooth on and off via NickelMenu.

Available commands are:
	enable
	disable
	toggle

I've been testing/using this modified version of NickelMenu on my Clara 2E and It should be compatible with all Bluetooth devices. 

This should address issue  #142 

Usage examples:
menu_item :main  :Bluetooth (enable)      :nickel_bluetooth     :enable
menu_item :main  :Bluetooth (disable)     :nickel_bluetooth     :disable
menu_item :main  :Bluetooth (toggle)      :nickel_bluetooth     :toggle
